### PR TITLE
Discogs service

### DIFF
--- a/app/controllers/api/v1/discogs_controller.rb
+++ b/app/controllers/api/v1/discogs_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::DiscogsController < ApplicationController
   def index
-
+    # @album = DiscogsService.get_album(params[:album])
+    @album = DiscogsService.get_album_data(params[:album])
+    require "pry"; binding.pry
   end
 end

--- a/app/controllers/api/v1/discogs_controller.rb
+++ b/app/controllers/api/v1/discogs_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::DiscogsController < ApplicationController
+  def index
+
+  end
+end

--- a/app/services/discogs_service.rb
+++ b/app/services/discogs_service.rb
@@ -1,0 +1,31 @@
+class DiscogsService
+  def self.conn
+    # require "pry"; binding.pry
+    faraday = Faraday.new(url: 'https://api.discogs.com')
+  end
+
+  def self.parse(response)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def self.get_album(album)
+    response = conn.get('/database/search') do |f|
+      f.params['key'] = ENV['key']
+      f.params['secret'] = ENV['secret']
+      f.params['q'] = album
+      f.params['format'] = "album"
+    end
+    album_q = parse(response)[:results][0][:master_id]
+    album_q
+  end
+
+  def self.get_album_resource(album)
+    id = get_album(album).to_s
+    response = Faraday.get("https://api.discogs.com/masters/#{id}")
+    parse(response)
+  end
+
+  def self.get_album_data(album)
+    self.get_album_resource(album)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :discogs, only: [:index]
+    end
+  end
 end

--- a/spec/cassettes/Discogs_API_request/Returns_realease_data_for_album_query_params_from_user.yml
+++ b/spec/cassettes/Discogs_API_request/Returns_realease_data_for_album_query_params_from_user.yml
@@ -1,0 +1,777 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.discogs.com/database/search?format=album&key=AFcwKjXbJFZHYnHlIdje&q=The%20Payback&secret=lmOhJlbzEyLbjyrTosVYmRZiSClBZVqT
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 May 2021 01:04:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Discogs-Ratelimit:
+      - '60'
+      X-Discogs-Ratelimit-Remaining:
+      - '60'
+      X-Discogs-Ratelimit-Used:
+      - '0'
+      Access-Control-Allow-Headers:
+      - Content-Type, authorization, User-Agent, Private-Auth-Secret, Discogs-UID
+      Access-Control-Allow-Methods:
+      - HEAD,OPTIONS,GET,OPTIONS
+      Access-Control-Expose-Headers:
+      - Location
+      Content-Language:
+      - en
+      X-Discogs-Media-Type:
+      - discogs.v2
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - public, must-revalidate
+      Strict-Transport-Security:
+      - max-age=15724800
+    body:
+      encoding: ASCII-8BIT
+      string: '{"pagination": {"page": 1, "pages": 39, "per_page": 50, "items": 1949,
+        "urls": {"last": "https://api.discogs.com/database/search?key=AFcwKjXbJFZHYnHlIdje&secret=lmOhJlbzEyLbjyrTosVYmRZiSClBZVqT&q=The+Payback&format=album&page=39&per_page=50",
+        "next": "https://api.discogs.com/database/search?key=AFcwKjXbJFZHYnHlIdje&secret=lmOhJlbzEyLbjyrTosVYmRZiSClBZVqT&q=The+Payback&format=album&page=2&per_page=50"}},
+        "results": [{"country": "US", "year": "1973", "format": ["Vinyl", "LP", "Album"],
+        "label": ["Polydor", "Polydor", "Polydor Incorporated", "International Recording",
+        "Advantage Sound", "Advantage Sound", "Dynatone Publishing Co.", "Belinda
+        Music, Inc.", "Unichappell & Co.", "Polydor Incorporated", "Sterling Sound"],
+        "type": "master", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"], "id":
+        33990, "barcode": ["2-3007 A", "2-3007 B", "2-3007 C", "2-3007 D", "PD-2-3007-A-1A",
+        "PD-2-3007-B-1B", "PD-2-3007-C-1B", "PD-2-3007-D-1A", "PD\u22192-3007-A-1A
+        \u2461  10-13-73", "PD-2-3007-B-1A \u2461", "PD-2-3007-C-1A", "PD-2-3007-D-1A",
+        "STERLING RL", "BMI"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/master/33990", "catno": "PD 2-3007", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/f6CfVzmLodKt6YxX4Bfi5KVS6Q8=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-719877-1247870750.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/MUELn9ObTL-ZpxyUgF5M9D_Kumc=/fit-in/600x591/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-719877-1247870750.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/masters/33990", "community": {"want":
+        14232, "have": 8159}}, {"country": "US", "year": "1973", "format": ["Vinyl",
+        "LP", "Album"], "label": ["Polydor", "Polydor", "Polydor Incorporated", "International
+        Recording", "Advantage Sound", "Advantage Sound", "Dynatone Publishing Co.",
+        "Belinda Music, Inc.", "Unichappell & Co.", "Polydor Incorporated", "Sterling
+        Sound"], "type": "release", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"],
+        "id": 719877, "barcode": ["2-3007 A", "2-3007 B", "2-3007 C", "2-3007 D",
+        "PD-2-3007-A-1A", "PD-2-3007-B-1B", "PD-2-3007-C-1B", "PD-2-3007-D-1A", "PD\u22192-3007-A-1A
+        \u2461  10-13-73", "PD-2-3007-B-1A \u2461", "PD-2-3007-C-1A", "PD-2-3007-D-1A",
+        "STERLING RL", "BMI"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/719877", "catno": "PD 2-3007", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/f6CfVzmLodKt6YxX4Bfi5KVS6Q8=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-719877-1247870750.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/MUELn9ObTL-ZpxyUgF5M9D_Kumc=/fit-in/600x591/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-719877-1247870750.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/719877", "community": {"want":
+        1663, "have": 1624}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album"]}]}, {"country": "US", "year": "1973",
+        "format": ["Vinyl", "LP", "Album"], "label": ["Polydor"], "type": "release",
+        "genre": ["Funk / Soul"], "style": ["Soul", "Funk"], "id": 3414903, "barcode":
+        [], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/3414903", "catno": "PD 2-3007", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/XrNTx6m1DsAskxOT92DAxZI0Z74=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-3414903-1334144478.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/dgkVCqt2FxY515JEIZ3ZJJC2I9A=/fit-in/600x606/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-3414903-1334144478.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/3414903", "community": {"want":
+        1175, "have": 753}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album"]}]}, {"country": "US", "year": "1973",
+        "format": ["Vinyl", "LP", "Album", "Stereo"], "label": ["Polydor", "Polydor",
+        "Polydor", "International Recording", "Advantage Sound", "Advantage Sound",
+        "Dynatone Publishing Co.", "Belinda Music, Inc.", "Unichappell & Co.", "Polydor
+        Incorporated", "Polydor Incorporated", "Sterling Sound", "All Disc Records,
+        Inc."], "type": "release", "genre": ["Funk / Soul"], "style": ["Funk", "Soul"],
+        "id": 4282599, "barcode": ["22", "PD 2-3007 A", "PD 2-3007 B", "PD 2-3007
+        C", "PD 2-3007 D", "22 PD-2-3007-A-1A 10-13-73 STERLING RL", "22 PD-2-3007-B-1B
+        STERLING", "22 PD-2-3007-C-1A STERLING RL", "22 PD-2-3007-D-1A STERLING RL",
+        "22 PD-2-3007-A-1B STERLING RL", "22 PD-2-3007-B-1B STERLING", "22 PD-2-3007-C-
+        1B STERLING", "22 PD-2-3007-D-DJ STERLING", " 22 PD-2-3007-A-1A 10-13-73 STERLING
+        RL", "22 PD-2-3007-B-1A STERLING RL", "22 PD-2-3007-C- 1B STERLING", "22 PD-2-3007-D-1B
+        STERLING RL", "BMI"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/4282599", "catno": "PD 2-3007", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/ijEaFCu-giAR7lQypSXIxssOA8Y=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-4282599-1360612846-3258.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/uH98dhGED5VZaAPhQW3eDluyDlo=/fit-in/450x450/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-4282599-1360612846-3258.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/4282599", "community": {"want":
+        811, "have": 644}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "text": "All Disc Press", "descriptions": ["LP", "Album", "Stereo"]}]},
+        {"country": "US", "genre": ["Funk / Soul"], "format": ["Vinyl", "LP", "Album",
+        "Reissue"], "style": ["Soul", "Funk"], "id": 1981916, "label": ["Polydor",
+        "Polydor", "Polydor Incorporated", "Polydor Incorporated", "Rainbo Records",
+        "Rainbo Records", "Rainbo Records", "Rainbo Records"], "type": "release",
+        "barcode": ["PD2 3007-A  S-34815", "PD2 3007-B  S-34816", "PD2 3007-C  S-34817",
+        "PD2 3007-D  S-34818", "PD 2-3007 A", "PD 2-3007 B", "PD 2-3007 C", "PD 2-3007
+        D"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/1981916", "catno": "PD-2-3007", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/oEqBfhk8tdjYXz6c6GSVBYCtvM0=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-1981916-1403795748-5151.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/zYGjmaRIoKWMbAYppq-lPL5RYQM=/fit-in/600x599/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-1981916-1403795748-5151.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/1981916", "community": {"want":
+        550, "have": 1009}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "text": "Gatefold", "descriptions": ["LP", "Album", "Reissue"]}]}, {"country":
+        "US", "year": "2014", "format": ["Vinyl", "LP", "Album", "Reissue"], "label":
+        ["Polydor", "Universal Records Inc.", "Universal Records Inc.", "Universal
+        Music Distribution", "Sterling Sound", "United Record Pressing"], "type":
+        "release", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"], "id": 6205299,
+        "barcode": ["6 02537 97585 3", "0602537975853", "B0021512-01A RJ STERLING",
+        "B0021512-01B RJ STERLING", "B0021512-01C RJ STERLING \u24ca", "B0021512-01D
+        RJ STERLING"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/6205299", "catno": "B0021512-01",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/cQ1f2xbs9YP849uDFc6hwy1XGb4=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-6205299-1608008184-8664.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/ngmgxlPy5_crwH9PjUFyy7e1vv4=/fit-in/600x598/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-6205299-1608008184-8664.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/6205299", "community": {"want":
+        558, "have": 729}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "text": "Gatefold", "descriptions": ["LP", "Album", "Reissue"]}]}, {"country":
+        "Germany", "year": "1973", "format": ["Vinyl", "LP", "Album", "Stereo"], "label":
+        ["Polydor", "Polydor Incorporated", "Phonodisc GmbH", "Gerhard Kaiser GmbH",
+        "Dynatone Publishing Co.", "Belinda Music, Inc.", "Unichappell & Co.", "International
+        Recording", "Advantage Sound", "Advantage Sound", "Phonodisc GmbH"], "type":
+        "release", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"], "id": 804277,
+        "barcode": ["2488 160", "2488 161", "2488 160 S1 \u2117 1973 320 3 K", "2488
+        160 S2 \u2117 1973 320 3 N", "2488 161 S3 \u2117 1973 320 2 L", "2488 161
+        S4 \u2117 1973 320 3 G", "GEMA", "BMI"], "master_id": 33990, "master_url":
+        "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/804277",
+        "catno": "2679 025", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/KcsO8YlA84PA9DwnHAzQ9IMVnm8=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-804277-1569696041-2971.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/Zh2TG62rB98f9eBecAhJRPbapmQ=/fit-in/600x591/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-804277-1569696041-2971.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/804277", "community": {"want":
+        659, "have": 575}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album", "Stereo"]}]}, {"country": "US", "year":
+        "1973", "format": ["Vinyl", "LP", "Album"], "label": ["Polydor", "Polydor
+        Incorporated", "International Recording", "Advantage Sound", "Advantage Sound",
+        "Sterling Sound", "Polydor Incorporated", "Columbia Records Pressing Plant,
+        Pitman"], "type": "release", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"],
+        "id": 6769932, "barcode": ["BMI", "PD-2-3007-A-1A  10-13-73", "PD-2-3007-B-1A",
+        "PD-2-3007-C-1A \u2461", "PD-2-3007-D-1A", "PD-2-3007-A-1A  10-13-73 \u2461",
+        "PD-2-3007-B-1A  \u2461", "PD-2-3007-C-1A", "PD-2-3007-D-1A", "STERLING RL"],
+        "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/6769932", "catno": "PD-2-3007", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/-dHYnFwR0_mMgxRWFb6FoOWDXXE=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-6769932-1457379301-4098.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/weT2VciipmBWFDetoMZvZfcvq3Q=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-6769932-1457379301-4098.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/6769932", "community": {"want":
+        557, "have": 275}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "text": "Pitman Pressing, Gatefold", "descriptions": ["LP", "Album"]}]},
+        {"country": "Europe", "genre": ["Funk / Soul"], "format": ["CD", "Album",
+        "Reissue", "Remastered"], "style": ["Funk"], "id": 616254, "label": ["Polydor",
+        "PolyGram Records, Inc.", "PolyGram Records, Inc.", "International Recording",
+        "Advantage Sound", "Advantage Sound", "PolyGram Studios", "Universal M & L,
+        Germany"], "type": "release", "barcode": ["BIEM/MCPS", "731451713729", "LC
+        0309", "PY 899", "07314 517 137-2 03 + 51000207", "MADE IN GERMANY BY UNIVERSAL
+        M & L  D", "IFPI 0124", "IFPI L002"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/616254", "catno": "517 137-2", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/UJZ8cKspG2qat51UOFoH_0a9M3o=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-616254-1231625404.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/SM5GQ6f3BvvGPDMRgA6acNk7D9I=/fit-in/591x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-616254-1231625404.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/616254", "community": {"want":
+        198, "have": 492}, "format_quantity": 1, "formats": [{"name": "CD", "qty":
+        "1", "descriptions": ["Album", "Reissue", "Remastered"]}]}, {"country": "US",
+        "year": "1973", "format": ["Vinyl", "LP", "Album"], "label": ["Polydor", "Polydor",
+        "International Recording", "Advantage Sound", "Advantage Sound", "Dynatone
+        Publishing Co.", "Belinda Music, Inc.", "Unichappell & Co.", "Polydor Incorporated",
+        "Polydor Incorporated", "Sterling Sound", "Columbia Records Pressing Plant,
+        Pitman"], "type": "release", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"],
+        "id": 3559131, "barcode": ["PD 2-3007-A", "PD 2-3007-B", "PD 2-3007-C", "PD
+        2-3007-D", "PD-2-3007-A-1A 10-13-73 STERLING RL P", "PD-2-3007-B-1A-1-11 P
+        STERLING RL ", "PD-2-3007-C-1A-1 STERLING RL P", "PD-2-3007-D-DJ-1 STERLING
+        P", "BMI"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/The-Godfather-Of-Soul-James-Brown-The-Payback/release/3559131", "catno":
+        "PD 2-3007", "title": "The Godfather Of Soul James Brown* - The Payback",
+        "thumb": "https://img.discogs.com/1l7_KIZPHVmUM4R9xwrFK9GlSlo=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-3559131-1339182439-6251.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/9HuHIkILG76WvQ0doaplNuB6Vq0=/fit-in/600x594/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-3559131-1339182439-6251.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/3559131", "community": {"want":
+        527, "have": 136}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "text": "Pitman Pressing, Gatefold", "descriptions": ["LP", "Album"]}]},
+        {"country": "US", "genre": ["Funk / Soul"], "format": ["CD", "Album", "Reissue",
+        "Remastered"], "style": ["Funk"], "id": 555962, "label": ["Polydor", "Polygram
+        Records, Inc.", "Polygram Records, Inc.", "International Recording", "Rodel
+        Studios", "United Artists Recording Studio", "Advantage Sound", "Advantage
+        Sound", "PolyGram Studios", "Polygram Records, Inc.", "Polygram Records, Inc."],
+        "type": "release", "barcode": ["7 314-517137-2 9", "314 517 1372 40%", "[Universal
+        logo] 314 517 1372 40% L", "MADE IN USA BY EC", "MADE IN USA BY ECD", "IFPI
+        L007", "IFPI 0325", "IFPI 0318"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/555962", "catno": "314 517 137-2",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/69j_Bh_N4UDxNEhtYO7pME4vcFI=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-555962-1247870197.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/qYQH_CxqU_Rcbjoxy-J33yHznp4=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-555962-1247870197.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/555962", "community": {"want":
+        216, "have": 426}, "format_quantity": 1, "formats": [{"name": "CD", "qty":
+        "1", "descriptions": ["Album", "Reissue", "Remastered"]}]}, {"country": "UK",
+        "year": "1993", "format": ["Vinyl", "LP", "Album", "Reissue"], "label": ["Polydor"],
+        "type": "release", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"], "id":
+        37043, "barcode": [], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/37043", "catno": "517 137-1", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/oz1QCW_liEqgTEeNd-rGGy0jmLE=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-37043-001.jpg.jpg",
+        "cover_image": "https://img.discogs.com/YJawDCkrhWEJKfukxwCet9tGBI8=/fit-in/140x140/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-37043-001.jpg.jpg",
+        "resource_url": "https://api.discogs.com/releases/37043", "community": {"want":
+        455, "have": 104}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album", "Reissue"]}]}, {"country": "Spain", "year":
+        "1974", "format": ["Vinyl", "LP", "Album"], "label": ["Polydor", "Polydor,
+        S.A.", "Polydor Incorporated", "COFASA"], "type": "release", "genre": ["Funk
+        / Soul"], "style": ["Funk"], "id": 2374787, "barcode": ["M.23548-1974", "M.23549-1974",
+        "BIEM GEMA"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/2374787", "catno": "23 91 137/38",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/_HcLhHbBFiMs_0RP2yuCCr7ssRM=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-2374787-1496493653-4609.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/tbHjPWVmGfNtywSV84r95b7UOEQ=/fit-in/600x603/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-2374787-1496493653-4609.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/2374787", "community": {"want":
+        400, "have": 60}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "text": "Gatefold Sleeve", "descriptions": ["LP", "Album"]}]}, {"country":
+        "UK", "year": "1973", "format": ["Vinyl", "LP", "Album"], "label": ["Polydor",
+        "Polydor"], "type": "release", "genre": ["Funk / Soul"], "style": ["Soul",
+        "Funk"], "id": 4633993, "barcode": ["PD-2-3007-A-1A", "PD-2-3007-B-1B", "PD-2-3007-C-1B",
+        "PD-2-3007-D-1A"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/4633993", "catno": "PD-2-3007", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/PnIrrFXaTGk8j58-V9YytVHfLXc=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-4633993-1370587406-9305.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/G4OzZBTHnOUv5JnNF4GD33cCQbU=/fit-in/596x589/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-4633993-1370587406-9305.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/4633993", "community": {"want":
+        552, "have": 76}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album"]}]}, {"country": "Canada", "year": "1974",
+        "format": ["Vinyl", "LP", "Album", "Stereo"], "label": ["Polydor", "Polydor",
+        "Polydor", "Polydor Ltd.", "Polydor Ltd.", "Polydor Incorporated", "Dynatone
+        Publishing Co.", "Belinda Music, Inc.", "Unichappell & Co.", "International
+        Recording", "Advantage Sound", "Advantage Sound", "RCA Victor Studios, Montreal",
+        "RCA Records Pressing Plant, Smiths Falls, Ontario"], "type": "release", "genre":
+        ["Funk / Soul"], "style": ["Soul", "Funk"], "id": 3446688, "barcode": ["BMI",
+        "PD-2-3007-A", "PD-2-3007-B", "PD-2-3007-C", "PD-2-3007-D", "PD-2-3007-A G
+        M", "PD-2-3007-B G M", "PD-2-3007-C G M", "PD-2-3007-D G M"], "master_id":
+        33990, "master_url": "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/3446688",
+        "catno": "PD 2-3007", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/0u4-QuiFZ8emc3KEyMfn6W4F2sc=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-3446688-1520632300-2512.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/jZ4Ub4qZg7o87JypbbWHemwqqlE=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-3446688-1520632300-2512.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/3446688", "community": {"want":
+        448, "have": 155}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album", "Stereo"]}]}, {"country": "UK & Europe",
+        "genre": ["Funk / Soul"], "format": ["Vinyl", "LP", "Album", "Reissue", "Mispress"],
+        "style": ["Funk"], "id": 2338302, "label": ["Polydor", "International Recording",
+        "Advantage Sound", "Advantage Sound", "Polydor Incorporated", "Polydor Incorporated"],
+        "type": "release", "barcode": ["731451713712", "A33 517 137-1 S1 320", "A33
+        517 137-1 S2 320", "A33 517 137-1 S4 320", "A33 XXXXXXXXXXXXXXXX 320 517 137-1
+        S3", "517 137-1 (1)", "517 137-1 (2)", "LC 00309", "BIEM/MCPS"], "master_id":
+        33990, "master_url": "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/2338302",
+        "catno": "517 137-1", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/RtuL9ZINL4B0tZjQTVCL1zfIUDo=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-2338302-1348750501-6631.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/n9W70dVm7mdNzWdTFoGL7nvudxs=/fit-in/454x454/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-2338302-1348750501-6631.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/2338302", "community": {"want":
+        370, "have": 107}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album", "Reissue", "Mispress"]}]}, {"country":
+        "France", "year": "1973", "format": ["Vinyl", "LP", "Album"], "label": ["Polydor"],
+        "type": "release", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"], "id":
+        5322472, "barcode": ["PD-2-3007-A-1A", "PD-2-3007-B-1B", "PD-2-3007-C-1B",
+        "PD-2-3007-D-1A"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/5322472", "catno": "2675 084", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/Vt2J46HFsj2uF-FAXoqtpTxgNps=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-5322472-1467135808-2955.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/CMr09IKzHHjlKXA6ib8vdlzgXbw=/fit-in/600x603/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-5322472-1467135808-2955.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/5322472", "community": {"want":
+        410, "have": 118}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album"]}]}, {"country": "Italy", "year": "1974",
+        "format": ["Vinyl", "LP", "Album", "Stereo"], "label": ["Polydor"], "type":
+        "release", "genre": ["Funk / Soul"], "style": ["Funk", "Soul"], "id": 4047322,
+        "barcode": [], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/4047322", "catno": "2679 025 L",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/JKbhU1ps6L2Cubu8bEQTSWMD2Mk=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-4047322-1477928780-6600.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/LkMCrCmOI6qpdldpS9PJ8ktI9Tk=/fit-in/600x604/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-4047322-1477928780-6600.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/4047322", "community": {"want":
+        355, "have": 46}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "text": "Gatefold", "descriptions": ["LP", "Album", "Stereo"]}]}, {"country":
+        "US", "year": "1973", "format": ["Vinyl", "LP", "Album"], "label": ["Polydor"],
+        "type": "release", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"], "id":
+        11272551, "barcode": [], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/11272551", "catno": "PD 2-3007",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/77d6bMQ4rlYfJAZFgRyxDO2Dwi8=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-11272551-1513172754-4357.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/PNdgypY7Zi7cs7ml5iAZgMvKHIg=/fit-in/599x449/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-11272551-1513172754-4357.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/11272551", "community":
+        {"want": 318, "have": 80}, "format_quantity": 2, "formats": [{"name": "Vinyl",
+        "qty": "2", "text": "Gatefold", "descriptions": ["LP", "Album"]}]}, {"country":
+        "Europe", "genre": ["Funk / Soul"], "format": ["CD", "Album", "Reissue", "Remastered"],
+        "style": ["Funk"], "id": 6907262, "label": ["Polydor", "International Recording",
+        "Advantage Sound", "Advantage Sound", "Advantage Sound", "PolyGram Studios",
+        "PolyGram", "PolyGram Records, Inc.", "PolyGram Records, Inc.", "EDC, Germany"],
+        "type": "release", "barcode": ["7 314-517137-2 9", "731451713729", "LC 0309",
+        "PY 899", "BIEM/MCPS", "[Universal Logo x 4]", "07314 517 137-2 04 * 51000207",
+        "MADE IN GERMANY BY EDC A", "IFPI LV26", "IFPI 0131", "07314 517 137-2 05
+        * 51000207", "MADE IN GERMANY BY EDC G", "IFPI LV27", "IFPI 0131", "MADE IN
+        GERMANY BY EDC A", "IFPI LV26", "IFPI 0126"], "master_id": 33990, "master_url":
+        "https://api.discogs.com/masters/33990", "uri": "/The-Godfather-Of-Soul-James-Brown-The-Payback/release/6907262",
+        "catno": "517 137-2", "title": "The Godfather Of Soul James Brown* - The Payback",
+        "thumb": "https://img.discogs.com/pL363D2OV4FtIg1TLY1klLqPVwI=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-6907262-1453544951-4403.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/d0TfOZZ0kYNTdGSO_N17rxxQeEo=/fit-in/600x589/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-6907262-1453544951-4403.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/6907262", "community": {"want":
+        140, "have": 207}, "format_quantity": 1, "formats": [{"name": "CD", "qty":
+        "1", "descriptions": ["Album", "Reissue", "Remastered"]}]}, {"country": "Venezuela",
+        "year": "1974", "format": ["Vinyl", "LP", "Album"], "label": ["Polydor", "Polydor
+        S.A."], "type": "release", "genre": ["Funk / Soul"], "style": ["Funk", "Soul"],
+        "id": 5790075, "barcode": [], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/5790075", "catno": "30.139", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/diNR2Cds2Ter0OxHTbnTFhCB3bE=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-5790075-1447099762-5013.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/YKTEInbWJGFrQvB5J4icUKr7x1Q=/fit-in/388x387/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-5790075-1447099762-5013.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/5790075", "community": {"want":
+        289, "have": 17}, "format_quantity": 1, "formats": [{"name": "Vinyl", "qty":
+        "1", "descriptions": ["LP", "Album"]}]}, {"country": "South Africa", "year":
+        "1987", "format": ["Vinyl", "LP", "Album"], "label": ["Polydor", "Teal Trutone
+        Music", "Teal Trutone Music"], "type": "release", "genre": ["Funk / Soul"],
+        "style": ["Soul", "Funk"], "id": 2976293, "barcode": ["6001210010777", "2679-025
+        A", "2679-025 B", "2679-025 C", "2679-025 D"], "master_id": 33990, "master_url":
+        "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/2976293",
+        "catno": "DGL 935/6", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/T27JKV8P4XU0tZapm3GO25Tou7I=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-2976293-1369666780-1445.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/Zmrwl3Jpft_-hSl0F7D4dUcjYuU=/fit-in/597x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-2976293-1369666780-1445.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/2976293", "community": {"want":
+        336, "have": 10}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album"]}]}, {"country": "US", "genre": ["Funk
+        / Soul"], "format": ["CD", "Album", "Reissue", "Remastered", "Repress"], "style":
+        ["Funk"], "id": 7037196, "label": ["Polydor", "Polygram Records, Inc.", "Polygram
+        Records, Inc.", "Polygram Records, Inc.", "Polygram Records, Inc.", "International
+        Recording", "Rodel Studios", "United Artists Recording Studio", "Advantage
+        Sound", "Advantage Sound", "PolyGram Studios"], "type": "release", "barcode":
+        ["7 314-517137-2 9", "DIDX-151483 2", "IFPI L327", "IFPI 50F4"], "master_id":
+        33990, "master_url": "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/7037196",
+        "catno": "314 517 137-2", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/-y7JhJmFVAZ4566QSdEE7TMBzyw=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-7037196-1432232926-3409.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/XdUASB8V40j-2H7rLzlBs8KPQr8=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-7037196-1432232926-3409.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/7037196", "community": {"want":
+        140, "have": 178}, "format_quantity": 1, "formats": [{"name": "CD", "qty":
+        "1", "descriptions": ["Album", "Reissue", "Remastered", "Repress"]}]}, {"country":
+        "Greece", "year": "1974", "format": ["Vinyl", "LP", "Album"], "label": ["International
+        Polydor Production", "Polydor", "Phonogram", "Polydor Incorporated", "Columbia,
+        Athens", "\u0391\u03b4\u03b5\u03bb\u03c6\u03bf\u03af \u039d. \u03a0\u03b9\u03c4\u03c3\u03b9\u03bb\u03bf\u03cd
+        \u039f.\u0395."], "type": "release", "genre": ["Funk / Soul"], "style": ["Funk",
+        "Soul"], "id": 7864612, "barcode": ["A/A 2143", "BIEM"], "master_id": 33990,
+        "master_url": "https://api.discogs.com/masters/33990", "uri": "/The-Godfather-Of-Soul-James-Brown-The-Payback/release/7864612",
+        "catno": "2391 119", "title": "The Godfather Of Soul James Brown* - The Payback",
+        "thumb": "https://img.discogs.com/ZbSJHGU983d-T1XWt5Cdn-iNL1k=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-7864612-1507034920-5326.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/Ra4-SugWvh_GArT_U7VfdE5S7kI=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-7864612-1507034920-5326.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/7864612", "community": {"want":
+        234, "have": 24}, "format_quantity": 1, "formats": [{"name": "Vinyl", "qty":
+        "1", "descriptions": ["LP", "Album"]}]}, {"country": "Brazil", "year": "1974",
+        "format": ["Vinyl", "LP", "Album"], "label": ["Polydor", "Companhia Brasileira
+        De Discos Phonogram", "Matiz Gr\u00e1fica"], "type": "release", "genre": ["Funk
+        / Soul"], "style": ["Soul", "Funk"], "id": 7356936, "barcode": ["2929 016
+        A", "2929 016 B", "2929 017 A", "2929 017 B", "200 2929 016 A1 HL", "200 2929
+        016 B1 HL", "200 2929 017 A1 HL", "200 2929 017 B1 HL", "Serie De Luxo"],
+        "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/7356936", "catno": "2929 016/017",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/31QXUntJLv6n27H8SKGbiRwBkk0=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-7356936-1593779122-2190.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/IS2DRKWzfx48F0OYYF3TDc0N8WY=/fit-in/600x606/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-7356936-1593779122-2190.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/7356936", "community": {"want":
+        274, "have": 21}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album"]}]}, {"country": "US", "year": "1973",
+        "format": ["Vinyl", "LP", "Album", "Club Edition"], "label": ["Polydor", "Longines
+        Symphonette Society"], "type": "release", "genre": ["Funk / Soul"], "style":
+        ["Soul", "Funk"], "id": 11731106, "barcode": ["SKBO 1 95617 RI", "SKBO 2 95617
+        RI", "SKBO 3 95617 RI", "SKBO 4 95617 RI"], "master_id": 33990, "master_url":
+        "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/11731106",
+        "catno": "PD 2-3007", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/P6Eq3S2F3P0QjJmghbD3GPKHh6w=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-11731106-1583939707-3821.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/j2kD8UXnHqRlzfz9JWnEaVZhB4A=/fit-in/600x596/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-11731106-1583939707-3821.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/11731106", "community":
+        {"want": 233, "have": 26}, "format_quantity": 2, "formats": [{"name": "Vinyl",
+        "qty": "2", "text": "Longines Club Press", "descriptions": ["LP", "Album",
+        "Club Edition"]}]}, {"country": "Japan", "year": "1973", "format": ["Vinyl",
+        "LP", "Album"], "label": ["Polydor", "Polydor", "Polydor", "International
+        Recording", "Advantage Sound", "Advantage Sound", "Dynatone Publishing Co.",
+        "Belinda Music, Inc.", "Unichappell & Co.", "Polydor Incorporated", "Polydor
+        Incorporated", "Sterling Sound"], "type": "release", "genre": ["Funk / Soul"],
+        "style": ["Funk", "Soul"], "id": 12154044, "barcode": ["PD-2-3007-A-1C *stamped
+        MR inside circle* \u25b318423(2) STERLING", "PD-2-3007-B-1C *stamped MR inside
+        circle* \u25b318423-X(something) STERLING RL", "PD-2-3007-C-1C *stamped MR
+        inside circle* \u25b318424-X(something) STERLING RL", "PD-2-3007-D-1C *stamped
+        MR inside circle* \u25b318424-X(3) STERLING", "BMI"], "master_id": 33990,
+        "master_url": "https://api.discogs.com/masters/33990", "uri": "/The-Godfather-Of-Soul-James-Brown-The-Payback/release/12154044",
+        "catno": "PD 2-3007", "title": "The Godfather Of Soul James Brown* - The Payback",
+        "thumb": "https://img.discogs.com/hs0dVgUnsQIAwdmuVdpidUrx-Sk=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-12154044-1588997303-2299.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/rI62psQzTpJA2f6yTrIWC1XJSJ8=/fit-in/600x566/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-12154044-1588997303-2299.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/12154044", "community":
+        {"want": 210, "have": 19}, "format_quantity": 2, "formats": [{"name": "Vinyl",
+        "qty": "2", "descriptions": ["LP", "Album"]}]}, {"country": "South Korea",
+        "year": "1973", "format": ["Vinyl", "LP", "Album", "Unofficial Release"],
+        "label": ["Yegrin"], "type": "release", "genre": ["Funk / Soul"], "style":
+        ["Soul", "Funk"], "id": 4139946, "barcode": ["STR-19-1", "STR-19-2", "STR-19-3",
+        "STR-19-4"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/4139946", "catno": "STR-19", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/39OrbKeV4O3aKutTzyhk5MyOZsU=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-4139946-1512677183-2570.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/SAvXPcGSvy36JZpoXhna_xtuWZY=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-4139946-1512677183-2570.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/4139946", "community": {"want":
+        337, "have": 8}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album", "Unofficial Release"]}]}, {"country":
+        "Japan", "year": "2007", "format": ["CD", "Album"], "label": ["Circulations",
+        "Ultra-Vybe, Inc.", "Memory-Tech"], "type": "master", "genre": ["Electronic",
+        "Hip Hop"], "style": ["Hip Hop", "Broken Beat", "Neo Soul"], "id": 388672,
+        "barcode": ["4 526180 010906", "JASRAC", "CIRC002 MT F01", "IFPI L266", "IFPI
+        4473"], "master_id": 388672, "master_url": "https://api.discogs.com/masters/388672",
+        "uri": "/The-Big-Payback-The-Big-Payback/master/388672", "catno": "CIRC002",
+        "title": "The Big Payback - The Big Payback", "thumb": "https://img.discogs.com/WIOWZTmTKM6tqKwVzMVf9m25KOU=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-1105362-1192388854.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/H_rXcfSEqgq_w-aoQn7YqgSVPsk=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-1105362-1192388854.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/masters/388672", "community": {"want":
+        95, "have": 203}}, {"country": "Zimbabwe", "year": "1984", "format": ["Vinyl",
+        "LP", "Album"], "label": ["Trutone Music", "Polydor"], "type": "release",
+        "genre": ["Funk / Soul"], "style": ["Funk"], "id": 7864659, "barcode": [],
+        "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/7864659", "catno": "DPOL 155", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/llLNxbwyik2ehOwcwzPkYtJYl2U=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-7864659-1450454653-5329.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/C2IPDTdCuxjDn6u4yk5330Yh7Ac=/fit-in/388x389/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-7864659-1450454653-5329.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/7864659", "community": {"want":
+        234, "have": 1}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "descriptions": ["LP", "Album"]}]}, {"country": "Germany", "year": "2015",
+        "format": ["Vinyl", "LP", "Album", "Limited Edition", "Numbered"], "label":
+        ["HHV.DE", "HHV.DE", "HHV.DE", "Kasablanka"], "type": "release", "genre":
+        ["Electronic", "Hip Hop"], "style": ["Instrumental", "Jazzy Hip-Hop", "Broken
+        Beat"], "id": 6427272, "barcode": ["4260116724009"], "master_id": 388672,
+        "master_url": "https://api.discogs.com/masters/388672", "uri": "/The-Big-Payback-The-Big-Payback/release/6427272",
+        "catno": "HHV366", "title": "The Big Payback - The Big Payback", "thumb":
+        "https://img.discogs.com/S93Viw6t7In8kyFmEOzDVTlFjC4=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-6427272-1421279818-8697.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/I2DipipAC8K_B8GqryUt5DteuiE=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-6427272-1421279818-8697.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/6427272", "community": {"want":
+        65, "have": 167}, "format_quantity": 2, "formats": [{"name": "Vinyl", "qty":
+        "2", "text": "Clear", "descriptions": ["LP", "Album", "Limited Edition", "Numbered"]}]},
+        {"country": "US", "year": "1973", "format": ["8-Track Cartridge", "Album"],
+        "label": ["Polydor"], "type": "release", "genre": ["Funk / Soul"], "style":
+        ["Soul", "Funk"], "id": 5615218, "barcode": [], "master_id": 33990, "master_url":
+        "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/5615218",
+        "catno": "8F 2-3007", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/F6EpgOCNpgzpLQQyk8FBl30NjDE=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-5615218-1419108571-5503.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/gGv9C5hATXMdAHWSJdI5VmHAdQM=/fit-in/458x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-5615218-1419108571-5503.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/5615218", "community": {"want":
+        178, "have": 8}, "format_quantity": 1, "formats": [{"name": "8-Track Cartridge",
+        "qty": "1", "descriptions": ["Album"]}]}, {"country": "US", "genre": ["Funk
+        / Soul"], "format": ["CD", "Album", "Club Edition"], "style": ["Soul", "Funk"],
+        "id": 6056452, "label": ["Polydor"], "type": "release", "barcode": ["DIDX-015573",
+        "0 20831 - 4779 - 2 20"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/6056452", "catno": "P2-17137", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/Z7TVVk2JQNU7r-1F40lBbP_6g-Q=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-6056452-1409941452-3509.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/YQ-cJw7_3O3AWzCJyWojR2d0aAg=/fit-in/600x588/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-6056452-1409941452-3509.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/6056452", "community": {"want":
+        150, "have": 25}, "format_quantity": 1, "formats": [{"name": "CD", "qty":
+        "1", "descriptions": ["Album", "Club Edition"]}]}, {"country": "Japan", "year":
+        "2014", "format": ["CD", "Album", "Limited Edition", "Reissue", "Remastered"],
+        "label": ["Polydor", "Rare Groove Funk Best Collection 1000", "Universal Records",
+        "Universal Records", "USM Japan", "Universal Music LLC", "Universal Music
+        LLC"], "type": "release", "genre": ["Funk / Soul"], "style": ["Soul", "Funk"],
+        "id": 8897170, "barcode": ["4988005846006", "UICY-76589 MT 264", "IFPI LT46",
+        "IFPI 447J"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/8897170", "catno": "UICY-76589",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/RGTbkK7CuBPLChDDvyKIJxPSDeM=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-8897170-1550792869-1917.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/Ul_MDwi-lj8ziuhPcla9et1aTVQ=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-8897170-1550792869-1917.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/8897170", "community": {"want":
+        128, "have": 27}, "format_quantity": 1, "formats": [{"name": "CD", "qty":
+        "1", "descriptions": ["Album", "Limited Edition", "Reissue", "Remastered"]}]},
+        {"country": "US", "year": "1973", "format": ["Vinyl", "LP", "Album", "Promo"],
+        "label": ["Polydor", "Polydor", "Polydor", "International Recording", "Advantage
+        Sound", "Advantage Sound", "Dynatone Publishing Co.", "Belinda Music, Inc.",
+        "Unichappell & Co.", "Polydor Incorporated", "Polydor Incorporated", "Sterling
+        Sound"], "type": "release", "genre": ["Funk / Soul"], "style": ["Funk", "Soul"],
+        "id": 14422641, "barcode": ["PD 2-3007 A", "PD 2-3007 B", "PD 2-3007 C", "PD
+        2-3007 D", "PD-2-3007-A-DJ STERLING", "PD-2-3007-B-DJ STERLING", "PD-2-3007-C-DJ
+        STERLING", "PD-2-3007-D-DJ STERLING", "BMI"], "master_id": 33990, "master_url":
+        "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/14422641",
+        "catno": "PD 2-3007", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/5r6RDUSdRLEWXspw8b9DUPj5Acg=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-14422641-1574221790-5512.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/tv25Q7V89j7ezeM19gZ0JmMaMTM=/fit-in/600x604/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-14422641-1574221790-5512.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/14422641", "community":
+        {"want": 148, "have": 25}, "format_quantity": 2, "formats": [{"name": "Vinyl",
+        "qty": "2", "text": "DJ Runouts", "descriptions": ["LP", "Album", "Promo"]}]},
+        {"country": "Germany", "genre": ["Funk / Soul"], "format": ["Vinyl", "LP",
+        "Album"], "style": ["Soul", "Funk"], "id": 13244477, "label": ["Polydor",
+        "Polydor Incorporated", "Gerhard Kaiser GmbH", "International Recording",
+        "Advantage Sound", "Advantage Sound", "Dynatone Publishing Co.", "Belinda
+        Music", "Unichappell Music"], "type": "release", "barcode": ["2488 160 99",
+        "2488 161 99", "2488 160 S1 \u2117 1973 320 2 \u2319", "2488 160 S2 \u2117
+        1973 320 3 [symbol] U [tilted 90\u00b0 left]", "2488 161 S3 \u2117 1973 320
+        2 P [tilted 90\u00b0 left]", "2488 161 S4 \u2117 1973 320 2 P [tilted 90\u00b0
+        left]", "none"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/13244477", "catno": "2679 025", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/jQY-HSelzzkVF5S4BCT4jD4Xbyw=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-13244477-1550615228-7645.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/Ig6ZTvzsj0fyT8Eo2pc6Htl4CgA=/fit-in/600x593/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-13244477-1550615228-7645.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/13244477", "community":
+        {"want": 140, "have": 24}, "format_quantity": 2, "formats": [{"name": "Vinyl",
+        "qty": "2", "descriptions": ["LP", "Album"]}]}, {"country": "US", "year":
+        "1973", "format": ["8-Track Cartridge", "Album", "Club Edition"], "label":
+        ["Polydor", "Columbia House"], "type": "release", "genre": ["Funk / Soul"],
+        "style": ["Soul", "Funk"], "id": 5615227, "barcode": [], "master_id": 33990,
+        "master_url": "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/5615227",
+        "catno": "8F2 3007", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/CtTrOBfr_Kp2RBWn3alKFk3GRNI=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-5615227-1398049317-6110.png.jpg",
+        "cover_image": "https://img.discogs.com/9EiZy990hrB6mC1LJvjs9xHcSUs=/fit-in/367x487/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-5615227-1398049317-6110.png.jpg",
+        "resource_url": "https://api.discogs.com/releases/5615227", "community": {"want":
+        168, "have": 2}, "format_quantity": 1, "formats": [{"name": "8-Track Cartridge",
+        "qty": "1", "descriptions": ["Album", "Club Edition"]}]}, {"country": "US",
+        "genre": ["Funk / Soul"], "format": ["Cassette", "Album", "Reissue"], "style":
+        ["Soul", "Funk"], "id": 7193608, "label": ["Polydor", "Polydor Incorporated"],
+        "type": "release", "barcode": [], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/7193608", "catno": "CF2-3007", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/PJ7aFen5J-7yAkXqjQCXTFB9jC0=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-7193608-1435841759-3420.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/fHoJ2HiPhqPsEVZ33EAjtTsJJYM=/fit-in/279x429/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-7193608-1435841759-3420.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/7193608", "community": {"want":
+        150, "have": 6}, "format_quantity": 1, "formats": [{"name": "Cassette", "qty":
+        "1", "descriptions": ["Album", "Reissue"]}]}, {"country": "Europe", "genre":
+        ["Funk / Soul"], "format": ["CD", "Album", "Remastered", "Repress"], "style":
+        ["Funk"], "id": 10887862, "label": ["Polydor", "PolyGram Records, Inc.", "PolyGram
+        Records, Inc.", "International Recording", "Advantage Sound", "Advantage Sound",
+        "PolyGram Studios", "Sony DADC"], "type": "release", "barcode": ["731451713729",
+        "BIEM/MCPS", "LC 0309", "PY 899", "Sony DADC [Universal logo] 5171372 13 A00",
+        "IFPI L553", "IFPI 946P"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/10887862", "catno": "517 137-2",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/sCPll2Gfkm86XfHnNLDnY6CaPJ8=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-10887862-1505991290-2519.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/ERfvGJTjHtdbGMaHAp4DTY95eKg=/fit-in/301x300/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-10887862-1505991290-2519.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/10887862", "community":
+        {"want": 90, "have": 42}, "format_quantity": 1, "formats": [{"name": "CD",
+        "qty": "1", "descriptions": ["Album", "Remastered", "Repress"]}]}, {"country":
+        "US", "year": "1990", "format": ["CD", "Album"], "label": ["Rap-A-Lot Records",
+        "Priority Records"], "type": "master", "genre": ["Hip Hop"], "style": ["Gangsta"],
+        "id": 207885, "barcode": ["049925713220"], "master_id": 207885, "master_url":
+        "https://api.discogs.com/masters/207885", "uri": "/Choice-The-Big-Payback/master/207885",
+        "catno": "CDL 57132", "title": "Choice (2) - The Big Payback", "thumb": "https://img.discogs.com/mEAuBQ8XFmPedqhhQYM9sRFLxtY=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-1081626-1190663445.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/JoAZ91VDyZj4ijbj980_59bN8a8=/fit-in/370x363/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-1081626-1190663445.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/masters/207885", "community": {"want":
+        395, "have": 119}}, {"country": "US", "genre": ["Funk / Soul"], "format":
+        ["CD", "Album", "Reissue", "Remastered"], "style": ["Funk"], "id": 12296859,
+        "label": ["Polydor", "Polygram Records, Inc.", "Polygram Records, Inc.", "International
+        Recording", "Rodel Studios", "United Artists Recording Studio", "Advantage
+        Sound", "Advantage Sound", "PolyGram Studios", "Polygram Records, Inc.", "Polygram
+        Records, Inc."], "type": "release", "barcode": ["7 314-517137-2 9", "314 517
+        1372 01@ J", "none", "IFPI 0370"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/12296859", "catno": "314 517 137-2",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/lnEBE0mRQwSgQ9QUP5JQsmzRD8E=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-12296859-1532383479-9925.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/5IIMHAhn3kk0UL-kVwBWpCdsOjA=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-12296859-1532383479-9925.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/12296859", "community":
+        {"want": 70, "have": 21}, "format_quantity": 1, "formats": [{"name": "CD",
+        "qty": "1", "descriptions": ["Album", "Reissue", "Remastered"]}]}, {"country":
+        "US", "genre": ["Funk / Soul"], "format": ["CD", "Album", "Reissue", "Remastered"],
+        "style": ["Funk"], "id": 12395228, "label": ["Polydor", "Polygram Records,
+        Inc.", "Polygram Records, Inc.", "Advantage Sound", "International Recording",
+        "Rodel Studios", "United Artists Recording Studio", "Advantage Sound", "PolyGram
+        Studios", "PMDC, USA", "Polygram Records, Inc.", "Polygram Records, Inc."],
+        "type": "release", "barcode": ["7 314-517137-2 9", "0501", "314 517 1372 01@
+        N", "MADE IN USA BY PMDC", "none", "IFPI 0333", "314 517 1372 01@ M", "MADE
+        IN USA BY PMDC", "none", "IFPI 0307", "314 517 137-2 02@ A", "MADE IN USA
+        BY PMDC", "IFPI L006", "IFPI 0388", "314 517 137-2 02@ A", "IFPI L006", "IFPI
+        0389", "MADE IN USA BY PMDC", "314 517 137-2 02@ D", "IFPI L006"], "master_id":
+        33990, "master_url": "https://api.discogs.com/masters/33990", "uri": "/James-Brown-The-Payback/release/12395228",
+        "catno": "314 517 137-2", "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/V32ZoFHcEosLLEJi49p2QYrQUjc=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-12395228-1547581058-3405.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/WzMsfPruVNKWRWP2--3OGL_OCIM=/fit-in/600x589/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-12395228-1547581058-3405.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/12395228", "community":
+        {"want": 71, "have": 23}, "format_quantity": 1, "formats": [{"name": "CD",
+        "qty": "1", "descriptions": ["Album", "Reissue", "Remastered"]}]}, {"country":
+        "US", "year": "2019", "format": ["Cassette", "Album", "Unofficial Release",
+        "Stereo"], "label": ["Soul Mates Records"], "type": "master", "genre": ["Hip
+        Hop", "Funk / Soul"], "style": [], "id": 1621331, "barcode": [], "master_id":
+        1621331, "master_url": "https://api.discogs.com/masters/1621331", "uri": "/Amerigo-Gazaway-James-Brown-Notorious-BIG-The-Notorious-JBs-The-BIG-Payback/master/1621331",
+        "catno": "none", "title": "Amerigo Gazaway, James Brown, Notorious B.I.G.
+        - The Notorious J.B.''s: The B.I.G. Payback", "thumb": "https://img.discogs.com/zbVcFKxNihjUPD5eaetr77OPYGs=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-14268249-1571092775-4214.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/60qZM3pjptoXEiLG-jqVfLjISaY=/fit-in/600x595/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-14268249-1571092775-4214.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/masters/1621331", "community": {"want":
+        546, "have": 907}}, {"country": "US", "year": "1999", "format": ["CD", "Album"],
+        "label": ["PR Entertainment"], "type": "master", "genre": ["Hip Hop"], "style":
+        ["Gangsta", "G-Funk"], "id": 437454, "barcode": ["7 95955 44502 9", "Brownside/3686"],
+        "master_id": 437454, "master_url": "https://api.discogs.com/masters/437454",
+        "uri": "/Brownside-Payback/master/437454", "catno": "PRE 54450-2", "title":
+        "Brownside - Payback", "thumb": "https://img.discogs.com/8MlKlZ-6-zGanwelIBnXfvVRPOA=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-8703681-1543417631-4839.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/WkGhfutvmu1EsxuEqYTEezDqBME=/fit-in/600x605/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-8703681-1543417631-4839.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/masters/437454", "community": {"want":
+        145, "have": 53}}, {"country": "US", "year": "1990", "format": ["CD", "Album"],
+        "label": ["Rap-A-Lot Records", "Technidisc", "N-The-Water Publishing Inc.",
+        "N-The-Water Publishing Inc."], "type": "release", "genre": ["Hip Hop"], "style":
+        ["Gangsta"], "id": 1907744, "barcode": ["0 34744-0105-2 0", "034744010520",
+        "Technidisc #366-070-086-A 07/17/90J   RAP-A-LOT / THE BIG PAYBACK", "ASCAP"],
+        "master_id": 207885, "master_url": "https://api.discogs.com/masters/207885",
+        "uri": "/Choice-The-Big-Payback/release/1907744", "catno": "RAP 105-2", "title":
+        "Choice (2) - The Big Payback", "thumb": "https://img.discogs.com/LlLGz1zqbYHd8bX6EL8hWuGbYI8=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-1907744-1284969269.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/l6jgLvvzgQHhnGdQEyZeFxm9_N8=/fit-in/400x393/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-1907744-1284969269.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/1907744", "community": {"want":
+        81, "have": 25}, "format_quantity": 1, "formats": [{"name": "CD", "qty": "1",
+        "descriptions": ["Album"]}]}, {"country": "Canada", "year": "1973", "format":
+        ["8-Track Cartridge", "Album"], "label": ["Polydor"], "type": "release", "genre":
+        ["Funk / Soul"], "style": ["Soul", "Funk"], "id": 13104515, "barcode": [],
+        "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/13104515", "catno": "none", "title":
+        "James Brown - The Payback", "thumb": "https://img.discogs.com/gBs8f3Ct6_9muMWSrlDnM_OTBxs=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-13104515-1548121857-4929.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/PsywJdPyj9kOVn4gGNfvRXeF7FU=/fit-in/600x833/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-13104515-1548121857-4929.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/13104515", "community":
+        {"want": 66, "have": 0}, "format_quantity": 1, "formats": [{"name": "8-Track
+        Cartridge", "qty": "1", "descriptions": ["Album"]}]}, {"country": "US", "year":
+        "1977", "format": ["Vinyl", "LP", "Album"], "label": ["Baby Grand"], "type":
+        "master", "genre": ["Funk / Soul"], "style": ["Funk", "Disco"], "id": 869819,
+        "barcode": [], "master_id": 869819, "master_url": "https://api.discogs.com/masters/869819",
+        "uri": "/Paul-Zaza-Le-Payback/master/869819", "catno": "SE 1032", "title":
+        "Paul Zaza - Le Payback", "thumb": "https://img.discogs.com/M5QiLH5swPeFwiXtbasSajglD_k=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-2806552-1416046195-3633.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/uj68mzpoaMRuIjG695fHy0maQ4c=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-2806552-1416046195-3633.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/masters/869819", "community": {"want":
+        376, "have": 93}}, {"country": "Austria", "year": "2018", "format": ["Vinyl",
+        "LP", "Album"], "label": ["Electronic Purification Records", "Temple Of Disharmony"],
+        "type": "release", "genre": ["Electronic"], "style": ["Synthwave"], "id":
+        12218537, "barcode": [], "master_id": 1172831, "master_url": "https://api.discogs.com/masters/1172831",
+        "uri": "/Street-Cleaner-Payback/release/12218537", "catno": "WAVE 038", "title":
+        "Street Cleaner - Payback", "thumb": "https://img.discogs.com/r4cfMU0fciC3yUoz3FfGR10wB8M=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-12218537-1530731561-7564.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/q5oEfN-cPG_3rATp3NUZkcPrFwM=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-12218537-1530731561-7564.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/12218537", "community":
+        {"want": 63, "have": 101}, "format_quantity": 1, "formats": [{"name": "Vinyl",
+        "qty": "1", "descriptions": ["LP", "Album"]}]}, {"country": "US", "year":
+        "1977", "format": ["Vinyl", "LP", "Album"], "label": ["Baby Grand"], "type":
+        "release", "genre": ["Funk / Soul"], "style": ["Funk", "Disco"], "id": 2806552,
+        "barcode": [], "master_id": 869819, "master_url": "https://api.discogs.com/masters/869819",
+        "uri": "/Paul-Zaza-Le-Payback/release/2806552", "catno": "SE 1032", "title":
+        "Paul Zaza - Le Payback", "thumb": "https://img.discogs.com/M5QiLH5swPeFwiXtbasSajglD_k=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-2806552-1416046195-3633.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/uj68mzpoaMRuIjG695fHy0maQ4c=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-2806552-1416046195-3633.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/2806552", "community": {"want":
+        294, "have": 31}, "format_quantity": 1, "formats": [{"name": "Vinyl", "qty":
+        "1", "descriptions": ["LP", "Album"]}]}, {"country": "Unknown", "genre": ["Funk
+        / Soul"], "format": ["CD", "Album", "Reissue", "Remastered", "Stereo", "Mono"],
+        "style": ["Soul", "Funk"], "id": 15004898, "label": ["Polydor", "International
+        Recording", "Advantage Sound", "Advantage Sound", "Dynatone Publishing Co.",
+        "Belinda Music, Inc.", "Arvato"], "type": "release", "barcode": ["arvato 56136922/00731451713729
+        21 [4x Universal logo]", "IFPI 0789"], "master_id": 33990, "master_url": "https://api.discogs.com/masters/33990",
+        "uri": "/James-Brown-The-Payback/release/15004898", "catno": "517 137-2",
+        "title": "James Brown - The Payback", "thumb": "https://img.discogs.com/LEVdZ4eIzDyXMX2rB1xnoLqLqwA=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-15004898-1585401470-8942.jpeg.jpg",
+        "cover_image": "https://img.discogs.com/gcTy5pX4fjjlOSKkjtaygxk3Wjc=/fit-in/600x594/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-15004898-1585401470-8942.jpeg.jpg",
+        "resource_url": "https://api.discogs.com/releases/15004898", "community":
+        {"want": 37, "have": 11}, "format_quantity": 1, "formats": [{"name": "CD",
+        "qty": "1", "descriptions": ["Album", "Reissue", "Remastered", "Stereo", "Mono"]}]}]}'
+  recorded_at: Fri, 14 May 2021 01:04:09 GMT
+- request:
+    method: get
+    uri: https://api.discogs.com/masters/33990
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.4.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 May 2021 01:04:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Discogs-Ratelimit:
+      - '25'
+      X-Discogs-Ratelimit-Remaining:
+      - '24'
+      X-Discogs-Ratelimit-Used:
+      - '1'
+      Access-Control-Allow-Headers:
+      - Content-Type, authorization, User-Agent, Private-Auth-Secret, Discogs-UID
+      Access-Control-Allow-Methods:
+      - HEAD,OPTIONS,GET,OPTIONS
+      Access-Control-Expose-Headers:
+      - Location
+      Content-Language:
+      - en
+      X-Discogs-Media-Type:
+      - discogs.v2
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - public, must-revalidate
+      Strict-Transport-Security:
+      - max-age=15724800
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": 33990, "main_release": 719877, "most_recent_release": 6205299,
+        "resource_url": "https://api.discogs.com/masters/33990", "uri": "https://www.discogs.com/James-Brown-The-Payback/master/33990",
+        "versions_url": "https://api.discogs.com/masters/33990/versions", "main_release_url":
+        "https://api.discogs.com/releases/719877", "most_recent_release_url": "https://api.discogs.com/releases/6205299",
+        "num_for_sale": 237, "lowest_price": 3.61, "images": [{"type": "primary",
+        "uri": "", "resource_url": "", "uri150": "", "width": 600, "height": 591},
+        {"type": "secondary", "uri": "", "resource_url": "", "uri150": "", "width":
+        600, "height": 292}, {"type": "secondary", "uri": "", "resource_url": "",
+        "uri150": "", "width": 600, "height": 578}, {"type": "secondary", "uri": "",
+        "resource_url": "", "uri150": "", "width": 600, "height": 595}, {"type": "secondary",
+        "uri": "", "resource_url": "", "uri150": "", "width": 600, "height": 598},
+        {"type": "secondary", "uri": "", "resource_url": "", "uri150": "", "width":
+        600, "height": 599}, {"type": "secondary", "uri": "", "resource_url": "",
+        "uri150": "", "width": 600, "height": 595}], "genres": ["Funk / Soul"], "styles":
+        ["Soul", "Funk"], "year": 1973, "tracklist": [{"position": "A1", "type_":
+        "track", "title": "The Payback", "duration": "7:35"}, {"position": "A2", "type_":
+        "track", "title": "Doing The Best I Can", "duration": "7:50"}, {"position":
+        "B1", "type_": "track", "title": "Take Some, Leave Some", "duration": "8:22"},
+        {"position": "B2", "type_": "track", "title": "Shoot Your Shot", "duration":
+        "8:08"}, {"position": "C1", "type_": "track", "title": "Forever Suffering",
+        "duration": "5:42"}, {"position": "C2", "type_": "track", "title": "Time Is
+        Running Out Fast", "duration": "12:37"}, {"position": "D1", "type_": "track",
+        "title": "Stone To The Bone", "duration": "10:05"}, {"position": "D2", "type_":
+        "track", "title": "Mind Power", "duration": "10:35"}], "artists": [{"name":
+        "James Brown", "anv": "", "join": "", "role": "", "tracks": "", "id": 12596,
+        "resource_url": "https://api.discogs.com/artists/12596"}], "title": "The Payback",
+        "notes": "The Payback is the 37th studio album by James Brown. The album was
+        released in December 1973, by Polydor Records. It was originally scheduled
+        to become the soundtrack for the blaxploitation film Hell Up in Harlem, but
+        was rejected by the film''s producers, who dismissed it as \"the same old
+        James Brown stuff.\"  It went to #1 on the Soul Albums chart for two weeks
+        and cracked the Pop Albums chart in the Top 40. It was Brown''s only studio
+        album to be certified gold.\n\nThe title track went number one on the R&B
+        charts and has been heavily sampled by musical artists. ", "data_quality":
+        "Correct", "videos": [{"uri": "https://www.youtube.com/watch?v=b8Jan4ontUg",
+        "title": "James Brown- Take Some...Leave Some", "description": "", "duration":
+        515, "embed": true}, {"uri": "https://www.youtube.com/watch?v=D7ks03zsg1o",
+        "title": "The Payback", "description": "Provided to YouTube by Universal Music
+        Group\n\nThe Payback \u00b7 James Brown\n\nThe Payback\n\n\u2117 1973 Universal
+        Records, a Division of UMG Recordings, Inc.\n\nReleased on: 1973-01-01\n\nProducer,
+        Associated  Performer, Recording  Arranger, Vocalist: James Brown\nStu", "duration":
+        460, "embed": true}, {"uri": "https://www.youtube.com/watch?v=cknHGZkvG3Q",
+        "title": "James Brown- The Payback", "description": "", "duration": 460, "embed":
+        true}, {"uri": "https://www.youtube.com/watch?v=DRLNwl3-SJE", "title": "Doing
+        The Best I Can", "description": "Provided to YouTube by Universal Music Group\n\nDoing
+        The Best I Can \u00b7 James Brown\n\nThe Payback\n\n\u2117 1973 Universal
+        Records, a Division of UMG Recordings, Inc.\n\nReleased on: 1973-01-01\n\nProducer,
+        Associated  Performer, Recording  Arranger, Vocalist: James ", "duration":
+        461, "embed": true}, {"uri": "https://www.youtube.com/watch?v=HtDFhvCWGOc",
+        "title": "James Brown- Doing The Best I Can", "description": "", "duration":
+        459, "embed": true}, {"uri": "https://www.youtube.com/watch?v=4k1V0w7-Xrs",
+        "title": "Take Some - Leave Some", "description": "Provided to YouTube by
+        Universal Music Group\n\nTake Some - Leave Some \u00b7 James Brown\n\nThe
+        Payback\n\n\u2117 1973 Universal Records, a Division of UMG Recordings, Inc.\n\nReleased
+        on: 1973-01-01\n\nProducer, Associated  Performer, Recording  Arranger, Vocalist:
+        Jame", "duration": 514, "embed": true}, {"uri": "https://www.youtube.com/watch?v=r16GK_zm7sc",
+        "title": "Shoot Your Shot", "description": "Provided to YouTube by Universal
+        Music Group\n\nShoot Your Shot \u00b7 James Brown\n\nThe Payback\n\n\u2117
+        1973 Universal Records, a Division of UMG Recordings, Inc.\n\nReleased on:
+        1973-01-01\n\nProducer, Associated  Performer, Recording  Arranger: James
+        Brown\nStudio  P", "duration": 487, "embed": true}, {"uri": "https://www.youtube.com/watch?v=qGdQs5nn_Ug",
+        "title": "Forever Suffering", "description": "Provided to YouTube by Universal
+        Music Group\n\nForever Suffering \u00b7 James Brown\n\nThe Payback\n\n\u2117
+        1973 Universal Records, a Division of UMG Recordings, Inc.\n\nReleased on:
+        1973-01-01\n\nProducer, Associated  Performer, Recording  Arranger, Vocalist:
+        James Bro", "duration": 353, "embed": true}, {"uri": "https://www.youtube.com/watch?v=Oklr8eOwsVI",
+        "title": "Time Is Running Out Fast", "description": "Provided to YouTube by
+        Universal Music Group\n\nTime Is Running Out Fast \u00b7 James Brown\n\nThe
+        Payback\n\n\u2117 1973 Universal Records, a Division of UMG Recordings, Inc.\n\nReleased
+        on: 1973-01-01\n\nProducer, Associated  Performer, Recording  Arranger, Vocalist:
+        Ja", "duration": 767, "embed": true}, {"uri": "https://www.youtube.com/watch?v=QON_23CPKQQ",
+        "title": "Stone To The Bone", "description": "Provided to YouTube by Universal
+        Music Group\n\nStone To The Bone \u00b7 James Brown\n\nThe Payback\n\n\u2117
+        1973 Universal Records, a Division of UMG Recordings, Inc.\n\nReleased on:
+        1973-01-01\n\nProducer, Associated  Performer, Recording  Arranger, Vocalist,
+        Organ: Ja", "duration": 615, "embed": true}, {"uri": "https://www.youtube.com/watch?v=7naR12OPxRw",
+        "title": "Mind Power", "description": "Provided to YouTube by Universal Music
+        Group\n\nMind Power \u00b7 James Brown\n\nThe Payback\n\n\u2117 1973 UMG Recordings,
+        Inc.\n\nReleased on: 1973-01-01\n\nProducer: James Brown\nComposer  Lyricist:
+        Charles Fred A. Bobbit\nComposer  Lyricist: James Brown\nComposer  Lyrici",
+        "duration": 726, "embed": true}]}'
+  recorded_at: Fri, 14 May 2021 01:04:11 GMT
+recorded_with: VCR 6.0.0

--- a/spec/requests/api/v1/discogs_request_spec.rb
+++ b/spec/requests/api/v1/discogs_request_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'Discogs API request', type: :request do
+  it 'Returns realease data for album query params from user', :vcr do
+
+  get api_v1_discogs_path, params: {album: "The Payback"}
+
+  # forecast = JSON.parse(response.body, symbolize_names:true)
+  end
+end 


### PR DESCRIPTION
Adds service and controller for discogs, with index action returning album data. Include initial test. Much more needed. 